### PR TITLE
Get rid of some turbofish when parsing `Toolchain`.

### DIFF
--- a/src/ex_run.rs
+++ b/src/ex_run.rs
@@ -64,7 +64,7 @@ pub fn run_ex_all_tcs(ex_name: &str) -> Result<()> {
 }
 
 pub fn run_ex(ex_name: &str, tc: &str) -> Result<()> {
-    let tc = tc.parse::<toolchain::Toolchain>()?;
+    let tc: toolchain::Toolchain = tc.parse()?;
     let config = load_config(ex_name)?;
     run_exts(&config, &[tc])
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -139,7 +139,10 @@ impl Process<GlobalState> for Cmd {
                     Cmd::CreateLists,
                 ]);
             }
-            Cmd::PrepareToolchain(tc) => tc.0.parse::<toolchain::Toolchain>()?.prepare()?,
+            Cmd::PrepareToolchain(tc) => {
+                let tc: toolchain::Toolchain = tc.0.parse()?;
+                tc.prepare()?
+            }
             Cmd::BuildContainer => docker::build_container()?,
 
             // List creation
@@ -176,10 +179,7 @@ impl Process<GlobalState> for Cmd {
             Cmd::DefineEx(ex, tc1, tc2, mode, crates) => {
                 ex::define(ex::ExOpts {
                                name: ex.0,
-                               toolchains: vec![
-                    tc1.0.parse::<toolchain::Toolchain>()?,
-                    tc2.0.parse::<toolchain::Toolchain>()?,
-                ],
+                               toolchains: vec![tc1.0.parse()?, tc2.0.parse()?],
                                mode: mode,
                                crates: crates,
                            })?;
@@ -805,7 +805,7 @@ pub mod conv {
 
         fn from_str(tc: &str) -> Result<Tc> {
             use toolchain;
-            let _ = tc.parse::<toolchain::Toolchain>()?;
+            let tc: toolchain::Toolchain = tc.parse()?;
             Ok(Tc(tc.to_string()))
         }
     }


### PR DESCRIPTION
This is a followup to https://github.com/brson/cargobomb/pull/9#issuecomment-300354810