### PR TITLE
Switch to using standard logging macro names.

### DIFF
--- a/src/crates.rs
+++ b/src/crates.rs
@@ -14,7 +14,7 @@ use util;
 const CRATES_ROOT: &'static str = "https://crates-io.s3-us-west-1.amazonaws.com/crates";
 
 pub fn prepare(list: &[(ExCrate, PathBuf)]) -> Result<()> {
-    log!("preparing {} crates", list.len());
+    info!("preparing {} crates", list.len());
     let mut successes = 0;
     for &(ref crate_, ref dir) in list {
         match *crate_ {
@@ -53,13 +53,13 @@ pub fn prepare(list: &[(ExCrate, PathBuf)]) -> Result<()> {
 
 fn dl_registry(name: &str, vers: &str, dir: &Path) -> Result<()> {
     if dir.exists() {
-        log!("crate {}-{} exists at {}. skipping",
-             name,
-             vers,
-             dir.display());
+        info!("crate {}-{} exists at {}. skipping",
+              name,
+              vers,
+              dir.display());
         return Ok(());
     }
-    log!("downloading crate {}-{} to {}", name, vers, dir.display());
+    info!("downloading crate {}-{} to {}", name, vers, dir.display());
     let url = format!("{0}/{1}/{1}-{2}.crate", CRATES_ROOT, name, vers);
     let bin = dl::download(&url)
         .chain_err(|| format!("unable to download {}", url))?;
@@ -77,7 +77,7 @@ fn dl_registry(name: &str, vers: &str, dir: &Path) -> Result<()> {
 }
 
 fn dl_repo(url: &str, dir: &Path, sha: &str) -> Result<()> {
-    log!("downloading repo {} to {}", url, dir.display());
+    info!("downloading repo {} to {}", url, dir.display());
     gh_mirrors::reset_to_sha(url, sha)?;
     let src_dir = gh_mirrors::repo_dir(url)?;
     util::copy_dir(&src_dir, dir)

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -29,7 +29,7 @@ pub struct RustEnv<'a> {
 }
 
 pub fn create_rust_container(env: &RustEnv) -> Result<Container> {
-    log!("creating container for: {}", env.args.join(" "));
+    info!("creating container for: {}", env.args.join(" "));
 
     fs::create_dir_all(&env.work_dir.0);
     fs::create_dir_all(&env.cargo_home.0);
@@ -90,7 +90,7 @@ pub fn create_rust_container(env: &RustEnv) -> Result<Container> {
 
 pub fn run(source_path: &Path, target_path: &Path, args: &[&str]) -> Result<()> {
 
-    log!("running: {}", args.join(" "));
+    info!("running: {}", args.join(" "));
 
     let env = RustEnv {
         args: args,

--- a/src/ex_run.rs
+++ b/src/ex_run.rs
@@ -85,7 +85,7 @@ fn run_exts(config: &Experiment, tcs: &[Toolchain]) -> Result<()> {
         ExMode::UnstableFeatures => test_find_unstable_features,
     };
 
-    log!("running {} tests", total_crates);
+    info!("running {} tests", total_crates);
     for (ref c, _) in crates {
         for tc in tcs {
             let r = {
@@ -93,9 +93,9 @@ fn run_exts(config: &Experiment, tcs: &[Toolchain]) -> Result<()> {
                 if let Some(r) = existing_result {
                     skipped_crates += 1;
 
-                    log!("skipping crate {}. existing result: {}", c, r);
-                    log!("delete result file to rerun test: {}",
-                         result_file(ex_name, c, tc)?.display());
+                    info!("skipping crate {}. existing result: {}", c, r);
+                    let file = result_file(ex_name, c, tc)?;
+                    info!("delete result file to rerun test: {}", file.display());
                     Ok(r)
                 } else {
                     completed_crates += 1;
@@ -111,7 +111,7 @@ fn run_exts(config: &Experiment, tcs: &[Toolchain]) -> Result<()> {
 
             match r {
                 Err(ref e) => {
-                    log_err!("error testing crate {}:  {}", c, e);
+                    error!("error testing crate {}:  {}", c, e);
                     util::report_error(e);
                 }
                 Ok(ref r) => {
@@ -146,20 +146,20 @@ fn run_exts(config: &Experiment, tcs: &[Toolchain]) -> Result<()> {
                 format!("{:0} hours", remaining_time / 60 / 60)
             };
 
-            log!("progress: {} / {}",
-                 completed_crates + skipped_crates,
-                 total_crates);
-            log!("{} crates tested in {} s. {:.2} s/crate. {} crates remaining. ~{}",
-                 completed_crates,
-                 elapsed,
-                 seconds_per_test,
-                 remaining_tests,
-                 remaining_time_str);
-            log!("results: {} build-fail / {} test-fail / {} test-pass / {} errors",
-                 sum_build_fail,
-                 sum_test_fail,
-                 sum_test_pass,
-                 sum_errors);
+            info!("progress: {} / {}",
+                  completed_crates + skipped_crates,
+                  total_crates);
+            info!("{} crates tested in {} s. {:.2} s/crate. {} crates remaining. ~{}",
+                  completed_crates,
+                  elapsed,
+                  seconds_per_test,
+                  remaining_tests,
+                  remaining_time_str);
+            info!("results: {} build-fail / {} test-fail / {} test-pass / {} errors",
+                  sum_build_fail,
+                  sum_test_fail,
+                  sum_test_pass,
+                  sum_errors);
         }
     }
 
@@ -229,10 +229,10 @@ fn run_single_test<F>(ex_name: &str,
     let log_file = result_log(ex_name, c, toolchain)?;
 
     log::redirect(&log_file, || {
-        log!("testing {} against {} for {}",
-             c,
-             toolchain.to_string(),
-             ex_name);
+        info!("testing {} against {} for {}",
+              c,
+              toolchain.to_string(),
+              ex_name);
         let tc = toolchain.rustup_name();
         let target_path = toolchain.target_dir(ex_name);
         f(source_path, &target_path, &tc)
@@ -306,12 +306,12 @@ fn record_test_result(ex_name: &str,
     let result_dir = result_dir(ex_name, c, toolchain)?;
     fs::create_dir_all(&result_dir)?;
     let result_file = result_file(ex_name, c, toolchain)?;
-    log!("test result! ex: {}, c: {}, tc: {}, r: {}",
-         ex_name,
-         c,
-         toolchain.to_string(),
-         r);
-    log!("file: {}", result_file.display());
+    info!("test result! ex: {}, c: {}, tc: {}, r: {}",
+          ex_name,
+          c,
+          toolchain.to_string(),
+          r);
+    info!("file: {}", result_file.display());
     file::write_string(&result_file, &r.to_string())?;
     Ok(())
 }
@@ -372,7 +372,7 @@ fn test_find_unstable_features(source_path: &Path,
     let mut features: Vec<_> = features.into_iter().collect();
     features.sort();
     for feature in features {
-        log!("unstable-feature: {}", feature);
+        info!("unstable-feature: {}", feature);
     }
 
     Ok(TestResult::TestPass)

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -42,15 +42,15 @@ const QUERIES_PER: usize = 40;
 const TIME_PER: usize = 6;
 
 pub fn get_candidate_repos() -> Result<Vec<String>> {
-    log!("making up to {} queries. time: {} s. take a break",
-         QUERIES.len() * QUERIES_PER,
-         QUERIES.len() * QUERIES_PER * TIME_PER);
+    info!("making up to {} queries. time: {} s. take a break",
+          QUERIES.len() * QUERIES_PER,
+          QUERIES.len() * QUERIES_PER * TIME_PER);
 
     let mut urls = HashSet::new();
     'next_query: for q in QUERIES {
         for page in 1..(QUERIES_PER + 1) {
             let url = format!("{}&page={}", q, page);
-            log!("downloading {}", url);
+            info!("downloading {}", url);
 
             let response = if page < 20 {
                     dl::download_limit(&url, 10000)
@@ -61,7 +61,7 @@ pub fn get_candidate_repos() -> Result<Vec<String>> {
 
             // After some point, errors indicate the end of available results
             let mut response = if page > 20 && response.is_err() {
-                log!("error result. continuing");
+                info!("error result. continuing");
                 thread::sleep(Duration::from_secs(TIME_PER as u64));
                 continue 'next_query;
             } else {
@@ -71,13 +71,13 @@ pub fn get_candidate_repos() -> Result<Vec<String>> {
             let json: GitHubSearchPage = response.json()?;
 
             if json.items.is_empty() {
-                log!("no results. continuing");
+                info!("no results. continuing");
                 thread::sleep(Duration::from_secs(TIME_PER as u64));
                 continue 'next_query;
             }
 
             for item in json.items {
-                log!("found rust repo {}", item.full_name);
+                info!("found rust repo {}", item.full_name);
                 urls.insert(item.full_name);
             }
 
@@ -94,7 +94,7 @@ pub fn get_candidate_repos() -> Result<Vec<String>> {
 pub fn is_rust_app(name: &str) -> Result<bool> {
     let url = format!("https://raw.githubusercontent.com/{}/master/Cargo.lock",
                       name);
-    log!("testing {}", url);
+    info!("testing {}", url);
 
     let is_app = dl::download_no_retry(&url)
         .and_then(|mut response| {
@@ -106,10 +106,10 @@ pub fn is_rust_app(name: &str) -> Result<bool> {
         .unwrap_or(false);
 
     if is_app {
-        log!("{} contains a root lockfile at {}", name, url);
+        info!("{} contains a root lockfile at {}", name, url);
         Ok(true)
     } else {
-        log!("{} does not contain a root lockfile", name);
+        info!("{} does not contain a root lockfile", name);
         Ok(false)
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -8,7 +8,7 @@ pub fn shallow_clone_or_pull(url: &str, dir: &Path) -> Result<()> {
     let url = frob_url(url);
 
     if !dir.exists() {
-        log!("cloning {} into {}", url, dir.display());
+        info!("cloning {} into {}", url, dir.display());
         let r = run::run("git",
                          &["clone", "--depth", "1", &url, &dir.to_string_lossy()],
                          &[])
@@ -20,7 +20,7 @@ pub fn shallow_clone_or_pull(url: &str, dir: &Path) -> Result<()> {
 
         r
     } else {
-        log!("pulling existing url {} into {}", url, dir.display());
+        info!("pulling existing url {} into {}", url, dir.display());
         run::cd_run(dir, "git", &["pull"], &[]).chain_err(|| format!("unable to pull {}", url))
     }
 }
@@ -31,7 +31,7 @@ pub fn shallow_clone_or_pull(url: &str, dir: &Path) -> Result<()> {
 pub fn shallow_fetch_sha(url: &str, dir: &Path, sha: &str) -> Result<()> {
     let url = frob_url(url);
 
-    log!("ensuring sha {} in {}", sha, url);
+    info!("ensuring sha {} in {}", sha, url);
     let depths = &[1, 10, 100, 1000];
 
     let exists = || if dir.exists() {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -17,7 +17,7 @@ fn recent_path() -> PathBuf {
 }
 
 pub fn create_recent_list() -> Result<()> {
-    log!("creating recent list");
+    info!("creating recent list");
     fs::create_dir_all(LIST_DIR)?;
 
     let crates = registry::find_registry_crates()?;
@@ -26,7 +26,7 @@ pub fn create_recent_list() -> Result<()> {
         .map(|mut crate_| (crate_.name, crate_.versions.pop().expect("").0))
         .collect();
     write_crate_list(&recent_path(), &crates)?;
-    log!("recent crates written to {}", recent_path().display());
+    info!("recent crates written to {}", recent_path().display());
     Ok(())
 }
 
@@ -64,11 +64,11 @@ fn hot_path() -> PathBuf {
 }
 
 pub fn create_pop_list() -> Result<()> {
-    log!("creating hot list");
+    info!("creating hot list");
     fs::create_dir_all(LIST_DIR)?;
 
     let crates = registry::find_registry_crates()?;
-    log!("mapping reverse deps");
+    info!("mapping reverse deps");
 
     // Count the reverse deps of each crate
     let mut counts = HashMap::new();
@@ -99,7 +99,7 @@ pub fn create_pop_list() -> Result<()> {
         .map(|c| (c.name.clone(), c.versions.last().expect("").0.clone()))
         .collect();
     write_crate_list(&pop_path(), &crates)?;
-    log!("pop crates written to {}", pop_path().display());
+    info!("pop crates written to {}", pop_path().display());
     Ok(())
 }
 
@@ -110,7 +110,7 @@ pub fn read_pop_list() -> Result<Vec<(String, String)>> {
 }
 
 pub fn create_hot_list() -> Result<()> {
-    log!("creating hot list");
+    info!("creating hot list");
     fs::create_dir_all(LIST_DIR)?;
 
     let crates = registry::find_registry_crates()?;
@@ -131,7 +131,7 @@ pub fn create_hot_list() -> Result<()> {
         crate_map.insert(name.to_string(), versions);
     }
 
-    log!("mapping reverse deps");
+    info!("mapping reverse deps");
     // For each crate's dependency mark which revisions of the dep satisfy
     // semver
     for crate_ in &crates {
@@ -152,7 +152,7 @@ pub fn create_hot_list() -> Result<()> {
         }
     }
 
-    log!("calculating most popular crate versions");
+    info!("calculating most popular crate versions");
     // Take the version of each crate that satisfies the most rev deps
     let mut hot_crates = Vec::new();
     for crate_ in &crates {
@@ -174,7 +174,7 @@ pub fn create_hot_list() -> Result<()> {
     }
 
     write_crate_list(&hot_path(), &hot_crates)?;
-    log!("hot crates written to {}", hot_path().display());
+    info!("hot crates written to {}", hot_path().display());
     Ok(())
 }
 
@@ -193,22 +193,22 @@ fn gh_candidate_cache_path() -> PathBuf {
 }
 
 pub fn create_gh_candidate_list() -> Result<()> {
-    log!("creating gh candidate list");
+    info!("creating gh candidate list");
     fs::create_dir_all(LIST_DIR)?;
 
     let candidates = gh::get_candidate_repos()?;
     file::write_lines(&gh_candidate_path(), &candidates)?;
-    log!("candidate repos written to {}",
-         gh_candidate_path().display());
+    info!("candidate repos written to {}",
+          gh_candidate_path().display());
     Ok(())
 }
 
 pub fn create_gh_candidate_list_from_cache() -> Result<()> {
-    log!("creating gh candidate list from cache");
+    info!("creating gh candidate list from cache");
     fs::create_dir_all(LIST_DIR)?;
-    log!("copying {} to {}",
-         gh_candidate_cache_path().display(),
-         gh_candidate_path().display());
+    info!("copying {} to {}",
+          gh_candidate_cache_path().display(),
+          gh_candidate_path().display());
     fs::copy(&gh_candidate_cache_path(), &gh_candidate_path())?;
     Ok(())
 }
@@ -231,7 +231,7 @@ pub fn create_gh_app_list() -> Result<()> {
     let repos = read_gh_candidates_list()?;
     let delay = 100;
 
-    log!("testing {} repos. {}ms+", repos.len(), repos.len() * delay);
+    info!("testing {} repos. {}ms+", repos.len(), repos.len() * delay);
 
     // Look for Cargo.lock files in the Rust repos we're aware of
     let mut apps = Vec::new();
@@ -243,16 +243,16 @@ pub fn create_gh_app_list() -> Result<()> {
     }
 
     file::write_lines(&gh_app_path(), &apps)?;
-    log!("rust apps written to {}", gh_app_path().display());
+    info!("rust apps written to {}", gh_app_path().display());
     Ok(())
 }
 
 pub fn create_gh_app_list_from_cache() -> Result<()> {
-    log!("creating gh app list from cache");
+    info!("creating gh app list from cache");
     fs::create_dir_all(LIST_DIR)?;
-    log!("copying {} to {}",
-         gh_app_cache_path().display(),
-         gh_app_path().display());
+    info!("copying {} to {}",
+          gh_app_cache_path().display(),
+          gh_app_path().display());
     fs::copy(&gh_app_cache_path(), &gh_app_path())?;
     Ok(())
 }
@@ -315,7 +315,7 @@ pub fn read_all_lists() -> Result<Vec<Crate>> {
                                 }
                             }));
     } else {
-        log!("failed to load recent list. ignoring");
+        info!("failed to load recent list. ignoring");
     }
     if let Ok(hot) = hot {
         all.extend(hot.into_iter()
@@ -326,12 +326,12 @@ pub fn read_all_lists() -> Result<Vec<Crate>> {
                                 }
                             }));
     } else {
-        log!("failed to load hot list. ignoring");
+        info!("failed to load hot list. ignoring");
     }
     if let Ok(gh_apps) = gh_apps {
         all.extend(gh_apps.into_iter().map(|c| Crate::Repo { url: c }));
     } else {
-        log!("failed to load gh-app list. ignoring");
+        info!("failed to load gh-app list. ignoring");
     }
 
     if all.is_empty() {

--- a/src/log.rs
+++ b/src/log.rs
@@ -81,7 +81,7 @@ fn redirected_file() -> Option<PathBuf> {
     redirect.clone()
 }
 
-macro_rules! log {
+macro_rules! info {
     ($fmt:expr) => {
         $crate::log::log_local_stdout(
             #[cfg_attr(feature = "cargo-clippy", allow(useless_format))]
@@ -94,7 +94,7 @@ macro_rules! log {
     };
 }
 
-macro_rules! log_err {
+macro_rules! error {
     ($fmt:expr) => {
         $crate::log::log_local_stderr(
             #[cfg_attr(feature = "cargo-clippy", allow(useless_format))]
@@ -223,11 +223,11 @@ pub fn log_command_(mut cmd: Command, capture: bool) -> Result<ProcessOutput> {
     let stderr = rx_err.recv().expect("");
 
     if heartbeat_timed_out {
-        log!("process killed after not generating output for {} s",
-             HEARTBEAT_TIMEOUT_SECS);
+        info!("process killed after not generating output for {} s",
+              HEARTBEAT_TIMEOUT_SECS);
         bail!(ErrorKind::Timeout);
     } else if timed_out {
-        log!("process killed after max time of {} s", MAX_TIMEOUT_SECS);
+        info!("process killed after max time of {} s", MAX_TIMEOUT_SECS);
         bail!(ErrorKind::Timeout);
     }
 
@@ -238,11 +238,11 @@ pub fn log_command_(mut cmd: Command, capture: bool) -> Result<ProcessOutput> {
        })
 }
 
-pub fn log_child_stdout(line: &str) {
+fn log_child_stdout(line: &str) {
     log(&format!("blam! {}", line));
 }
 
-pub fn log_child_stderr(line: &str) {
+fn log_child_stderr(line: &str) {
     log(&format!("kablam! {}", line));
 }
 
@@ -280,8 +280,8 @@ lazy_static! {
 
 pub fn init() {
     START_TIME.deref();
-    log!("program args: {}",
-         env::args().skip(1).collect::<Vec<_>>().join(" "));
+    info!("program args: {}",
+          env::args().skip(1).collect::<Vec<_>>().join(" "));
 }
 
 pub fn finish() {
@@ -293,6 +293,6 @@ pub fn finish() {
         let seconds = duration % 60;
         format!("{}m {}s", minutes, seconds)
     };
-    log!("logs: {}", out_file().display());
-    log!("duration: {}", duration);
+    info!("logs: {}", global_log_name());
+    info!("duration: {}", duration);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,12 +72,12 @@ fn main() {
             false
         }
     };
-    log!("{}",
-         if success {
-             "command succeeded"
-         } else {
-             "command failed"
-         });
+    info!("{}",
+          if success {
+              "command succeeded"
+          } else {
+              "command failed"
+          });
     log::finish();
     process::exit(if success { 0 } else { 1 });
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -17,9 +17,9 @@ pub type Dep = (String, String);
 pub fn find_registry_crates() -> Result<Vec<Crate>> {
     fs::create_dir_all(LOCAL_DIR)?;
     update_registry()?;
-    log!("loading registry");
+    info!("loading registry");
     let r = read_registry()?;
-    log!("registry loaded");
+    info!("registry loaded");
     Ok(r)
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -80,7 +80,7 @@ pub fn gen(ex_name: &str) -> Result<()> {
     let res = TestResults { crates: res };
 
     let json = serde_json::to_string(&res)?;
-    log!("writing results to {}", results_file(ex_name).display());
+    info!("writing results to {}", results_file(ex_name).display());
     file::write_string(&results_file(ex_name), &json)?;
 
     write_html_files(&ex_dir)?;
@@ -137,7 +137,7 @@ fn write_html_files(dir: &Path) -> Result<()> {
     let js_out = dir.join("report.js");
     let css_out = dir.join("report.css");
 
-    log!("writing report to {}", html_out.display());
+    info!("writing report to {}", html_out.display());
 
     file::write_string(&html_out, html_in)?;
     file::write_string(&js_out, js_in)?;

--- a/src/run.rs
+++ b/src/run.rs
@@ -26,7 +26,7 @@ pub fn run_full(cd: Option<&Path>, name: &str, args: &[&str], env: &[(&str, &str
         cmd.current_dir(cd);
     }
 
-    log!("running `{}`", cmdstr);
+    info!("running `{}`", cmdstr);
     let out = log::log_command(cmd)?;
 
     if out.status.success() {
@@ -53,7 +53,7 @@ pub fn run_capture(cd: Option<&Path>,
         cmd.current_dir(cd);
     }
 
-    log!("running `{}`", cmdstr);
+    info!("running `{}`", cmdstr);
     let out = log::log_command_capture(cmd)?;
 
     if out.status.success() {

--- a/src/toml_frobber.rs
+++ b/src/toml_frobber.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use toml::{Parser, Value};
 
 pub fn frob_toml(dir: &Path, name: &str, vers: &str, out: &Path) -> Result<()> {
-    log!("frobbing {}-{}", name, vers);
+    info!("frobbing {}-{}", name, vers);
     let toml_str = file::read_string(&dir.join("Cargo.toml"))
         .chain_err(|| "no cargo.toml?")?;
     let mut parser = Parser::new(&toml_str);
@@ -22,7 +22,7 @@ pub fn frob_toml(dir: &Path, name: &str, vers: &str, out: &Path) -> Result<()> {
             for (dep_name, v) in deps.iter_mut() {
                 if let Value::Table(ref mut dep_props) = *v {
                     if dep_props.contains_key("path") {
-                        log!("removing path from {} in {}-{}", dep_name, name, vers);
+                        info!("removing path from {} in {}-{}", dep_name, name, vers);
                     }
                     if dep_props.remove("path").is_some() {
                         changed = true;
@@ -34,7 +34,7 @@ pub fn frob_toml(dir: &Path, name: &str, vers: &str, out: &Path) -> Result<()> {
 
     // Eliminate workspaces
     if toml.remove("workspace").is_some() {
-        log!("removing workspace from {}-{}", name, vers);
+        info!("removing workspace from {}-{}", name, vers);
         changed = true;
     }
 
@@ -42,7 +42,7 @@ pub fn frob_toml(dir: &Path, name: &str, vers: &str, out: &Path) -> Result<()> {
         let toml = Value::Table(toml);
         file::write_string(out, &format!("{}", toml))?;
 
-        log!("frobbed toml written to {}", out.display());
+        info!("frobbed toml written to {}", out.display());
     }
 
     Ok(())

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -94,7 +94,7 @@ fn rustup_run(name: &str, args: &[&str], env: &[(&str, &str)]) -> Result<()> {
 }
 
 fn install_rustup() -> Result<()> {
-    log!("installing rustup");
+    info!("installing rustup");
     let rustup_url = &format!("{}/{}/rustup-init{}",
             RUSTUP_BASE_URL,
             &util::this_target(),
@@ -143,7 +143,7 @@ pub fn make_executable(path: &Path) -> Result<()> {
 }
 
 fn update_rustup() -> Result<()> {
-    log!("updating rustup");
+    info!("updating rustup");
     util::try_hard(|| {
                        rustup_run(&rustup_exe(), &["self", "update"], &[])
                            .chain_err(|| "unable to run rustup self-update")
@@ -151,7 +151,7 @@ fn update_rustup() -> Result<()> {
 }
 
 fn init_toolchain_from_dist(toolchain: &str) -> Result<()> {
-    log!("installing toolchain {}", toolchain);
+    info!("installing toolchain {}", toolchain);
     util::try_hard(|| {
                        rustup_run(&rustup_exe(), &["toolchain", "install", toolchain], &[])
                            .chain_err(|| "unable to install toolchain via rustup")
@@ -159,7 +159,7 @@ fn init_toolchain_from_dist(toolchain: &str) -> Result<()> {
 }
 
 fn init_toolchain_from_repo(repo: &str, sha: &str) -> Result<()> {
-    log!("installing toolchain {}#{}", repo, sha);
+    info!("installing toolchain {}#{}", repo, sha);
 
     fs::create_dir_all(TOOLCHAIN_DIR)?;
     let dir = &Path::new(TOOLCHAIN_DIR).join(sha);

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,9 +20,9 @@ pub fn try_hard_limit<F, R>(ms: usize, f: F) -> Result<R>
         if r.is_ok() {
             return r;
         } else if let Err(ref e) = r {
-            log_err!("{}", e);
+            error!("{}", e);
         };
-        log!("retrying in {}ms", i * ms);
+        info!("retrying in {}ms", i * ms);
         thread::sleep(Duration::from_millis((i * ms) as u64));
     }
 
@@ -41,20 +41,20 @@ pub fn remove_dir_all(dir: &Path) -> Result<()> {
 }
 
 pub fn report_error(e: &Error) {
-    log_err!("{}", e);
+    error!("{}", e);
 
     for e in e.iter().skip(1) {
-        log_err!("caused by: {}", e);
+        error!("caused by: {}", e);
     }
 }
 
 pub fn report_panic(e: &Any) {
     if let Some(e) = e.downcast_ref::<String>() {
-        log_err!("panicked: {}", e);
+        error!("panicked: {}", e);
     } else if let Some(e) = e.downcast_ref::<&'static str>() {
-        log_err!("panicked: {}", e);
+        error!("panicked: {}", e);
     } else {
-        log_err!("panicked");
+        error!("panicked");
     }
 }
 
@@ -81,7 +81,7 @@ pub fn this_target() -> String {
 pub fn copy_dir(src_dir: &Path, dest_dir: &Path) -> Result<()> {
     use walkdir::*;
 
-    log!("copying {} to {}", src_dir.display(), dest_dir.display());
+    info!("copying {} to {}", src_dir.display(), dest_dir.display());
 
     if dest_dir.exists() {
         remove_dir_all(dest_dir)


### PR DESCRIPTION
This is in preparation for switching to something like `log` or `slog`.

This is a separate PR, since I think they'll be easier to review separately.