### PR TITLE
Fix network logic when we encounter last page of GitHub results.

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -220,7 +220,7 @@ pub mod conv {
                 "acquire toolchains, build containers, build crate lists"),
 
             // List creation
-            cmd("create-lists-full", "create all the lists of crates"),
+            cmd("create-list-full", "create all the lists of crates"),
 
             // Master experiment prep
             cmd("define-ex", "define an experiment")


### PR DESCRIPTION
Broke in https://github.com/brson/cargobomb/pull/26

If we encounter the last page of GitHub search results, we don't expect an
`Err` to be returned from reqwest, we expect an `Ok(Response)` with a 422
status code.