### PR TITLE
Add Travis badge to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cargobomb
 
+[![Build Status](https://travis-ci.org/brson/cargobomb.svg?branch=master)](https://travis-ci.org/brson/cargobomb)
+
 Cargobomb is a laboratory for running experiments across a large body
 of Rust source code. Its primary purpose is to detect regressions in
 the Rust compiler, and it does this by building large numbers of


### PR DESCRIPTION
Since we don't currently test branches once pulled to master (when there are multiple outstanding PRs landing), it'd be nice to see the CI status on the main page, without needing to go to travis.