### PR TITLE
Switch to Ubuntu 16.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ENV LAST_UPDATE=2017-05-25
+
 RUN apt-get update
 
 # Tools
@@ -10,7 +12,7 @@ RUN apt-get install -y cmake
 # Native deps
 RUN apt-get install -y libssl-dev
 # Hopefully this pulls in lots of stuff
-RUN apt-get build-dep -y libgtk-3-0
+RUN apt-get install -y --install-suggests libgtk-3-dev
 
 WORKDIR /source
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get install -y cmake
 # Native deps
 RUN apt-get install -y libssl-dev
 # Hopefully this pulls in lots of stuff
-RUN apt-get install -y --install-suggests libgtk-3-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --install-suggests libgtk-3-dev
 
 WORKDIR /source
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.10
+FROM ubuntu:16.04
 
 RUN apt-get update
 


### PR DESCRIPTION
Ubuntu 15.10 was end-of-lifed back in 2016-07-28, so it's not getting
security updates and etc:

https://lists.ubuntu.com/archives/ubuntu-announce/2016-July/000210.html

So lets switch to the LTS Ubuntu 16.04