### PR TITLE
Cleanup handling of command killing.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,8 +7,9 @@ error_chain! {
     }
 
     errors {
-        Timeout {
+        Timeout(what: &'static str, when: u64) {
             description("the operation timed out")
+            display("process killed after {} {}s", what, when)
         }
     }
 }


### PR DESCRIPTION
There is some weirdness that I haven't debugged around killing a process that is spamming output, but that isn't new.