### PR TITLE
Move all cargo invocations into docker.

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,4 +1,3 @@
-use dirs::{CARGO_HOME, RUSTUP_HOME};
 use errors::*;
 use run;
 use std::env;
@@ -55,23 +54,7 @@ pub struct ContainerConfig<'a> {
 }
 
 
-pub fn run(source_path: &Path, target_path: &Path, args: &[&str]) -> Result<()> {
-
-    info!("running: {}", args.join(" "));
-
-    let env = RustEnv {
-        args: args,
-        work_dir: (source_path.into(), Perm::ReadOnly),
-        cargo_home: (Path::new(CARGO_HOME).into(), Perm::ReadOnly),
-        rustup_home: (Path::new(RUSTUP_HOME).into(), Perm::ReadOnly),
-        // This is configured as CARGO_TARGET_DIR by the docker container itself
-        target_dir: (target_path.into(), Perm::ReadWrite),
-    };
-
-    run_container(rust_container(env))
-}
-
-pub fn run_container(config: ContainerConfig) -> Result<()> {
+pub fn run(config: ContainerConfig) -> Result<()> {
     let c = Container::create_container(config)?;
     defer!{{
         if let Err(e) = c.delete() {

--- a/src/ex.rs
+++ b/src/ex.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use toml_frobber;
-use toolchain::{self, Toolchain};
+use toolchain::{self, CargoState, Toolchain};
 use util;
 
 #[derive(Serialize, Deserialize)]
@@ -424,10 +424,9 @@ fn capture_lockfile(ex: &Experiment,
                     path: &Path,
                     toolchain: &Toolchain)
                     -> Result<()> {
-    let manifest_path = path.join("Cargo.toml").to_string_lossy().to_string();
-    let args = &["generate-lockfile", "--manifest-path", &*manifest_path];
+    let args = &["generate-lockfile", "--manifest-path", "Cargo.toml"];
     toolchain
-        .run_cargo(&ex.name, args)
+        .run_cargo(&ex.name, path, args, CargoState::Unlocked)
         .chain_err(|| format!("unable to generate lockfile for {}", crate_))?;
 
     let src_lockfile = &path.join("Cargo.lock");
@@ -472,10 +471,9 @@ pub fn fetch_deps(ex: &Experiment, toolchain: &Toolchain) -> Result<()> {
             with_frobbed_toml(ex, c, path)?;
             with_captured_lockfile(ex, c, path)?;
 
-            let manifest_path = path.join("Cargo.toml").to_string_lossy().to_string();
-            let args = &["fetch", "--locked", "--manifest-path", &*manifest_path];
+            let args = &["fetch", "--locked", "--manifest-path", "Cargo.toml"];
             toolchain
-                .run_cargo(&ex.name, args)
+                .run_cargo(&ex.name, path, args, CargoState::Unlocked)
                 .chain_err(|| format!("unable to fetch deps for {}", c))?;
 
             Ok(())

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -216,6 +216,15 @@ impl Toolchain {
         let mut full_args = vec!["cargo", &*toolchain_arg];
         full_args.extend_from_slice(args);
 
-        docker::run(source_dir, &ex_target_dir, &full_args)
+        info!("running: {}", full_args.join(" "));
+        let rust_env = docker::RustEnv {
+            args: &full_args,
+            work_dir: (source_dir.into(), docker::Perm::ReadOnly),
+            cargo_home: (Path::new(CARGO_HOME).into(), docker::Perm::ReadOnly),
+            rustup_home: (Path::new(RUSTUP_HOME).into(), docker::Perm::ReadOnly),
+            // This is configured as CARGO_TARGET_DIR by the docker container itself
+            target_dir: (ex_target_dir, docker::Perm::ReadWrite),
+        };
+        docker::run(docker::rust_container(rust_env))
     }
 }


### PR DESCRIPTION
Fixes #69 in the cases were it has been an issue. Specifically https://github.com/rust-lang/cargo/issues/4066 will cause trying to generate lockfiles for cargo-web to leak processes. 