### PR TITLE
Update cargo-update version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,12 @@ env:
 
 before_script:
   - export PATH=$HOME/.cargo/bin:$PATH
-  - cargo install --force --git https://github.com/nabijaczleweli/cargo-update cargo-update
+  - |
+    if ! type -p cargo-install-update; then
+        cargo install --force cargo-update
+    else
+        cargo install-update -i cargo-update
+    fi
   - |
     if [[  $TRAVIS_RUST_VERSION =~ nightly-* ]]; then
         cargo install-update -i "clippy#$CLIPPY_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,10 @@ env:
 
 before_script:
   - export PATH=$HOME/.cargo/bin:$PATH
-  - type -p cargo-install-update || cargo install --force cargo-update
+  - cargo install --force --git https://github.com/nabijaczleweli/cargo-update cargo-update
   - |
     if [[  $TRAVIS_RUST_VERSION =~ nightly-* ]]; then
-      if ! type -p cargo-clippy || [[ "$(cargo-clippy -V)" != $CLIPPY_VERSION ]] ; then
-         cargo install --force --vers "$CLIPPY_VERSION" clippy
-      fi
+        cargo install-update -i "clippy#$CLIPPY_VERSION"
     fi
   - cargo install-update -i rustfmt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ language: rust
 cache: cargo
 rust:
   - stable
-  - nightly-2017-06-03
+  - nightly-2017-06-08
 
 env:
   global:
     # Version of clippy known to work with pinned nightly.
-    - CLIPPY_VERSION=0.0.137
+    - CLIPPY_VERSION=0.0.138
 
 before_script:
   - export PATH=$HOME/.cargo/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
     fi
   - |
     if [[  $TRAVIS_RUST_VERSION =~ nightly-* ]]; then
-        cargo install-update -i "clippy#$CLIPPY_VERSION"
+        cargo install-update -i "clippy:$CLIPPY_VERSION"
     fi
   - cargo install-update -i rustfmt
 script:


### PR DESCRIPTION
This allows us to simplify the logic for installing cargo-clippy. (Thangs to @nabijaczleweli for the quick resolution to https://github.com/nabijaczleweli/cargo-update/issues/37).