### PR TITLE
Simplify callers of `ex_crates_and_dirs`.

### DIFF
--- a/src/crates.rs
+++ b/src/crates.rs
@@ -32,8 +32,13 @@ pub fn prepare(list: &[(ExCrate, PathBuf)]) -> Result<()> {
                 }
                 // crates.io doesn't rate limit. Go fast
             }
-            ExCrate::Repo { ref url, ref sha } => {
-                let r = dl_repo(url, dir, sha).chain_err(|| format!("unable to download {}", url));
+            ExCrate::Repo {
+                ref org,
+                ref name,
+                ref sha,
+            } => {
+                let url = format!("https://github.com/{}/{}", org, name);
+                let r = dl_repo(&url, dir, sha).chain_err(|| format!("unable to download {}", url));
                 if let Err(e) = r {
                     util::report_error(&e);
                 } else {

--- a/src/ex_run.rs
+++ b/src/ex_run.rs
@@ -42,7 +42,7 @@ fn run_exts(ex: &Experiment, tcs: &[Toolchain]) -> Result<()> {
     let db = FileDB::for_experiment(ex);
     verify_toolchains(ex, tcs)?;
 
-    let crates = ex_crates_and_dirs(ex)?;
+    let crates = ex.crates()?;
 
     // Just for reporting progress
     let total_crates = crates.len() * tcs.len();
@@ -65,7 +65,7 @@ fn run_exts(ex: &Experiment, tcs: &[Toolchain]) -> Result<()> {
     };
 
     info!("running {} tests", total_crates);
-    for (ref c, _) in crates {
+    for c in &crates {
         for tc in tcs {
             let writer = db.for_crate(c, tc);
             let r = {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -3,6 +3,7 @@ use errors::*;
 use ex::ExCrate;
 use file;
 use gh;
+use gh_mirrors;
 use registry;
 use semver::{Version, VersionReq};
 use std::collections::{HashMap, HashSet};
@@ -346,10 +347,12 @@ impl Crate {
     pub fn into_ex_crate(self, shas: &HashMap<String, String>) -> Result<ExCrate> {
         match self {
             Crate::Version { name, version } => Ok(ExCrate::Version { name, version }),
-            Crate::Repo { url } => {
-                if let Some(sha) = shas.get(&url) {
+            Crate::Repo { ref url } => {
+                if let Some(sha) = shas.get(url) {
+                    let (org, name) = gh_mirrors::gh_url_to_org_and_name(url)?;
                     Ok(ExCrate::Repo {
-                        url,
+                        org,
+                        name,
                         sha: sha.to_string(),
                     })
                 } else {

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,7 +1,6 @@
 use errors::*;
 use ex;
 use file;
-use gh_mirrors;
 use handlebars::Handlebars;
 use mime::{self, Mime};
 use results::{CrateResultWriter, ExperimentResultDB, FileDB, TestResult};
@@ -72,7 +71,7 @@ pub fn generate_report(ex: &ex::Experiment) -> Result<TestResults> {
             let comp = compare(&crate1, &crate2);
 
             CrateResult {
-                name: crate_to_name(&krate).unwrap_or_else(|_| "<unknown>".into()),
+                name: crate_to_name(&krate),
                 res: comp,
                 runs: [crate1, crate2],
             }
@@ -135,16 +134,17 @@ pub fn gen<W: ReportWriter + Display>(ex_name: &str, dest: &W) -> Result<()> {
 }
 
 
-fn crate_to_name(c: &ex::ExCrate) -> Result<String> {
+fn crate_to_name(c: &ex::ExCrate) -> String {
     match *c {
         ex::ExCrate::Version {
             ref name,
             ref version,
-        } => Ok(format!("{}-{}", name, version)),
-        ex::ExCrate::Repo { ref url, ref sha } => {
-            let (org, name) = gh_mirrors::gh_url_to_org_and_name(url)?;
-            Ok(format!("{}.{}.{}", org, name, sha))
-        }
+        } => format!("{}-{}", name, version),
+        ex::ExCrate::Repo {
+            ref org,
+            ref name,
+            ref sha,
+        } => format!("{}.{}.{}", org, name, sha),
     }
 }
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -49,9 +49,9 @@ pub fn generate_report(ex: &ex::Experiment) -> Result<TestResults> {
     let db = FileDB::for_experiment(ex);
     assert_eq!(ex.toolchains.len(), 2);
 
-    let res = ex::ex_crates_and_dirs(ex)?
+    let res = ex.crates()?
         .into_iter()
-        .map(|(krate, _)| {
+        .map(|krate| {
             // Any errors here will turn into unknown results
             let crate_results = ex.toolchains.iter().map(|tc| -> Result<BuildTestResult> {
                 let writer = db.for_crate(&krate, tc);
@@ -82,9 +82,9 @@ pub fn generate_report(ex: &ex::Experiment) -> Result<TestResults> {
     Ok(TestResults { crates: res })
 }
 
-pub fn write_logs<W: ReportWriter>(ex: &ex::Experiment, dest: &W) -> Result<()> {
+fn write_logs<W: ReportWriter>(ex: &ex::Experiment, dest: &W) -> Result<()> {
     let db = FileDB::for_experiment(ex);
-    for (krate, _) in ex::ex_crates_and_dirs(ex)? {
+    for krate in ex.crates()? {
         for tc in &ex.toolchains {
             let writer = db.for_crate(&krate, tc);
             let rel_log = writer.result_path_fragement();

--- a/src/results.rs
+++ b/src/results.rs
@@ -3,7 +3,6 @@ use ex::ExCrate;
 use ex::Experiment;
 use ex::ex_dir;
 use file;
-use gh_mirrors;
 use log;
 use std::fmt::{self, Display, Formatter};
 use std::fs;
@@ -38,11 +37,11 @@ fn crate_to_dir(c: &ExCrate) -> String {
             ref name,
             ref version,
         } => format!("reg/{}-{}", name, version),
-        ExCrate::Repo { ref url, ref sha } => {
-            let (org, name) =
-                gh_mirrors::gh_url_to_org_and_name(url).expect("malformed github repo name");
-            format!("gh/{}.{}.{}", org, name, sha)
-        }
+        ExCrate::Repo {
+            ref org,
+            ref name,
+            ref sha,
+        } => format!("gh/{}.{}.{}", org, name, sha),
     }
 }
 


### PR DESCRIPTION
About half the callers throw away the directory, so let those that do request it. In service of that, parse the URL earlier, so getting the directory can't fail.